### PR TITLE
Fix: Update checkstyle version to 8.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,14 +274,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.1</version>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>8.25</version>
-          </dependency>
-        </dependencies>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>checkstyle-check</id>

--- a/src/test/java/org/sdo/rendezvous/services/op/OwnershipVoucherVerifierTest.java
+++ b/src/test/java/org/sdo/rendezvous/services/op/OwnershipVoucherVerifierTest.java
@@ -101,10 +101,8 @@ public class OwnershipVoucherVerifierTest {
   @Test
   public void testVerifyOpKeyVerificationDisabled() throws Exception {
     Mockito.when(rendezvousConfig.isOpKeyVerification()).thenReturn(false);
-    ownershipVoucher
-        .getOwnershipVoucherEntries()[0]
-        .getOwnershipVoucherEntryBody()
-        .setGuidDeviceInfoHash(INVALID_GUID_DEVICE_HASH);
+    ownershipVoucher.getOwnershipVoucherEntries()[0]
+        .getOwnershipVoucherEntryBody().setGuidDeviceInfoHash(INVALID_GUID_DEVICE_HASH);
     ownershipVoucherVerifier.verify(ownershipVoucher);
   }
 
@@ -122,10 +120,8 @@ public class OwnershipVoucherVerifierTest {
 
   @Test(expectedExceptions = InvalidOwnershipVoucherException.class)
   public void testVerifyInvalidHash() throws Exception {
-    ownershipVoucher
-        .getOwnershipVoucherEntries()[0]
-        .getOwnershipVoucherEntryBody()
-        .setPreviousEntryHash(INVALID_HASH);
+    ownershipVoucher.getOwnershipVoucherEntries()[0]
+        .getOwnershipVoucherEntryBody().setPreviousEntryHash(INVALID_HASH);
     ownershipVoucherVerifier.verify(ownershipVoucher);
   }
 
@@ -186,8 +182,7 @@ public class OwnershipVoucherVerifierTest {
 
   @Test(expectedExceptions = InvalidOwnershipVoucherException.class)
   public void testVerifyInvalidEntryBody() throws Exception {
-    ownershipVoucher
-        .getOwnershipVoucherEntries()[0]
+    ownershipVoucher.getOwnershipVoucherEntries()[0]
         .getOwnershipVoucherEntryBody()
         .setGuidDeviceInfoHash(INVALID_GUID_DEVICE_HASH);
     ownershipVoucherVerifier.verify(ownershipVoucher);
@@ -195,17 +190,14 @@ public class OwnershipVoucherVerifierTest {
 
   @Test(expectedExceptions = InvalidOwnershipVoucherException.class)
   public void testVerifyInvalidPublicKeyInLastEntry() throws Exception {
-    ownershipVoucher
-        .getOwnershipVoucherEntries()[1]
-        .getOwnershipVoucherEntryBody()
-        .setPublicKey(INVALID_PUBKEY);
+    ownershipVoucher.getOwnershipVoucherEntries()[1]
+        .getOwnershipVoucherEntryBody().setPublicKey(INVALID_PUBKEY);
     ownershipVoucherVerifier.verify(ownershipVoucher);
   }
 
   @Test(expectedExceptions = InvalidOwnershipVoucherException.class)
   public void testVerifyPubKeyMissmatch() throws Exception {
-    ownershipVoucher
-        .getOwnershipVoucherEntries()[1]
+    ownershipVoucher.getOwnershipVoucherEntries()[1]
         .getOwnershipVoucherEntryBody()
         .setPublicKey(new PkX509Enc(PublicKeyType.ECDSA_P_256, new byte[] {}));
     ownershipVoucherVerifier.verify(ownershipVoucher);


### PR DESCRIPTION
There seems to be some issue with latest checkstyle plugin which reports
error for multi-line chained method calls if the first line doesn't have
any method calls.

Provided some alternate fixes to get-around the problem.

The commit doesn't introduce any functional change to the code.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>