### PR TITLE
Moving docker environment variable to a separate .env file

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -70,52 +70,6 @@ services:
         cpu_shares: 5
         mem_limit: 500m
         mem_reservation: 200m
-        environment:
-            # RENDEZVOUS KEYSTORE & TRUSTSTORE
-            # This is an example implementation. This should be updated in production deployment.
-            # Modify these parameters to reflect your keystore path and password.
-            SSL_TRUST_STORE: file:///certs/rendezvous-trusterRootCA.jks
-            SSL_TRUST_STORE_PASSWORD: 123456
-            SSL_KEY_STORE: file:///certs/rendezvous-keystore.jks
-            SSL_KEY_STORE_PASSWORD: 123456
-
-            # RENDEZVOUS_HMACSECRET - the BASE64-encoded algorithm-specific signing key to use to digitally sign the JWT
-            RENDEZVOUS_HMACSECRET: "efe08a5df188dac44a4534c9f8ca0aed1b7ef6003622a07bf8a331134b3c1af427a6d7ee298f25d7f911ae495a8356e4636c19ada91643bd0d8b4f7b2bb97156"
-
-            # RENDEZVOUS_SIGNATUREVERIFICATION - the signatures are not checked when the variable is set to false (possible options true | false)
-            RENDEZVOUS_SIGNATUREVERIFICATION: "true"
-
-            # RENDEZVOUS_OPKEYVERIFICATION - the Ownership Voucher is not checked when the variable is set to false (possible options true | false)
-            RENDEZVOUS_OPKEYVERIFICATION: "true"
-
-            # RENDEZVOUS_TOTOKENEXPIRATIONTIME - the expiration time for JWT counted in minutes
-            RENDEZVOUS_TOTOKENEXPIRATIONTIME: 15
-
-            # RENDEZVOUS_OWNERSHIPVOUCHERMAXENTRIES - maximum number of entries it is willing to accept in the Ownership Voucher
-            RENDEZVOUS_OWNERSHIPVOUCHERMAXENTRIES: 10
-
-            # RENDEZVOUS_WAITSECONDSLIMIT - default upper bound in seconds (4 weeks) how long the Internet location it is waiting for a Device to connect,
-            # if field "ws" (wait seconds) is above the default limit then "ws" is equal RENDEZVOUS_WAITSECONDSLIMIT
-            RENDEZVOUS_WAITSECONDSLIMIT: 2419200
-
-            # To use Verification Service in the Cloud change RENDEZVOUS_VERIFICATIONSERVICEHOST variable to point to proper address and set PROXY for SDO service if needed
-            # Do not set http_proxy and https_proxy if you use local Verification Service
-            # Non-production environment cloud verification sevice:
-            RENDEZVOUS_VERIFICATIONSERVICEHOST: https://verify.epid-sbx.trustedservices.intel.com
-            # Production environment cloud verification sevice:
-            #- RENDEZVOUS_VERIFICATIONSERVICEHOST: https://verify.epid.trustedservices.intel.com:443
-            #- RENDEZVOUS_VERIFICATIONSERVICEHOST: https://u-verification-service:1180
-            # http_proxy:
-            # https_proxy:
-
-
-            # SPRING PROPERTIES
-            SPRING_PROFILES_ACTIVE: production
-            SPRING_DATASOURCE_USERNAME: None
-            SPRING_DATASOURCE_PASSWORD: None
-
-            # REDIS_HOST, REDIS_PORT - Redis database host name and port for RV service to connect to
-            REDIS_HOST: localhost
-            REDIS_PORT: 6379
-            REDIS_PASSWORD: 
+        env_file:
+          - ./rendezvous.env
         pids_limit: 100

--- a/demo/rendezvous.env
+++ b/demo/rendezvous.env
@@ -1,0 +1,50 @@
+# Copyright 2020 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+# RENDEZVOUS KEYSTORE & TRUSTSTORE
+# This is an example implementation. This should be updated in production deployment.
+# Modify these parameters to reflect your keystore path and password.
+SSL_TRUST_STORE=file:///certs/rendezvous-trusterRootCA.jks
+SSL_TRUST_STORE_PASSWORD=123456
+SSL_KEY_STORE=file:///certs/rendezvous-keystore.jks
+SSL_KEY_STORE_PASSWORD=123456
+
+# RENDEZVOUS_HMACSECRET - the BASE64-encoded algorithm-specific signing key to use to digitally sign the JWT
+RENDEZVOUS_HMACSECRET="efe08a5df188dac44a4534c9f8ca0aed1b7ef6003622a07bf8a331134b3c1af427a6d7ee298f25d7f911ae495a8356e4636c19ada91643bd0d8b4f7b2bb97156"
+
+# RENDEZVOUS_SIGNATUREVERIFICATION - the signatures are not checked when the variable is set to false (possible options true | false)
+RENDEZVOUS_SIGNATUREVERIFICATION=true
+
+# RENDEZVOUS_OPKEYVERIFICATION - the Ownership Voucher is not checked when the variable is set to false (possible options true | false)
+RENDEZVOUS_OPKEYVERIFICATION=true
+
+# RENDEZVOUS_TOTOKENEXPIRATIONTIME - the expiration time for JWT counted in minutes
+RENDEZVOUS_TOTOKENEXPIRATIONTIME=15
+
+# RENDEZVOUS_OWNERSHIPVOUCHERMAXENTRIES - maximum number of entries it is willing to accept in the Ownership Voucher
+RENDEZVOUS_OWNERSHIPVOUCHERMAXENTRIES=10
+
+# RENDEZVOUS_WAITSECONDSLIMIT - default upper bound in seconds (4 weeks) how long the Internet location it is waiting for a Device to connect,
+# if field "ws" (wait seconds) is above the default limit then "ws" is equal RENDEZVOUS_WAITSECONDSLIMIT
+RENDEZVOUS_WAITSECONDSLIMIT=2419200
+
+# To use Verification Service in the Cloud change RENDEZVOUS_VERIFICATIONSERVICEHOST variable to point to proper address and set PROXY for SDO service if needed
+# Do not set http_proxy and https_proxy if you use local Verification Service
+# Non-production environment cloud verification sevice:
+RENDEZVOUS_VERIFICATIONSERVICEHOST=https://verify.epid-sbx.trustedservices.intel.com
+# Production environment cloud verification sevice:
+# RENDEZVOUS_VERIFICATIONSERVICEHOST=https://verify.epid.trustedservices.intel.com:443
+# RENDEZVOUS_VERIFICATIONSERVICEHOST=https://u-verification-service:1180
+# http_proxy=
+# https_proxy=
+
+
+# SPRING PROPERTIES
+SPRING_PROFILES_ACTIVE=production
+SPRING_DATASOURCE_USERNAME=None
+SPRING_DATASOURCE_PASSWORD=None
+
+# REDIS_HOST, REDIS_PORT - Redis database host name and port for RV service to connect to
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=


### PR DESCRIPTION
Moving the configuration properties and environment variables from
docker-compose.yml, to separate rendezvous.env files.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>