### PR TITLE
Updated smoke tests to run with verify goal

### DIFF
--- a/Jenkinsfile.yml
+++ b/Jenkinsfile.yml
@@ -68,7 +68,7 @@ node('ubuntu18.04-OnDemand') {
         print "Rendezvous-service smoke Tests with  Client-SDKDevice, SCT-Manufacturer"
         sh '''
           cd sdo-test
-          mvn clean test -Dgroups=CdeviceOnPremTests
+          mvn clean verify -Dgroups=CdeviceOnPremTests
         '''
         }
     } finally {


### PR DESCRIPTION
Run smoke tests using verify goal instead of test

Signed-off-by: Mareddy, Deepthi <deepthix.mareddy@intel.com>