### PR TITLE
Migrate to use Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Rendezvous service is a software service that permits the Device to find its cur
 
 ### System requirements
 
-* **Ubuntu 18.04**.
+* **Ubuntu 20.04**.
 * **Maven**.
 * **Java 11**.
 * **Docker Engine 18.09**. (Optional)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-FROM ubuntu:bionic
+FROM ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install -y git  \

--- a/build/README.md
+++ b/build/README.md
@@ -4,7 +4,7 @@ Docker Script for Building Rendezvous-Service repository. Using this script you 
 
 ## Prerequisites
 
-- Operating system: **Ubuntu 18.04.**
+- Operating system: **Ubuntu 20.04.**
 
 - Docker engine : **18.06.0**
 

--- a/demo/Dockerfile-rendezvous
+++ b/demo/Dockerfile-rendezvous
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y openjdk-11-jdk
 RUN apt-get install -y wget
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -11,7 +11,7 @@
 
 # System requirements
 
-* Operating system: Ubuntu 18.04.
+* Operating system: Ubuntu 20.04.
 
 *  Linux packages:<br/><br/>
 `Docker engine (minimum version 18.09)`<br/><br/>


### PR DESCRIPTION
Migrate build and runtime containers to use Ubuntu 20.04.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>