### PR TITLE
Upgrading 3rd-party package versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.2.RELEASE</version>
+    <version>2.3.5.RELEASE</version>
     <relativePath/>
   </parent>
 
@@ -26,14 +26,14 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-rest</artifactId>
-      <version>2.3.2.RELEASE</version>
+      <version>2.3.5.RELEASE</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jetty</artifactId>
-      <version>2.3.2.RELEASE</version>
+      <version>2.3.5.RELEASE</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
-      <version>2.3.2.RELEASE</version>
+      <version>2.3.5.RELEASE</version>
     </dependency>
 
     <dependency>
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>29.0-jre</version>
+      <version>30.0-jre</version>
       <scope>provided</scope>
     </dependency>
 
@@ -180,7 +180,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.3.2.RELEASE</version>
+        <version>2.3.5.RELEASE</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Upgrading versions of third-party packages to their latest available
releases.

org.springboot.* : 2.3.5.Release
com.google.guava : 30.0-jre

Signed-off-by: Davis Benny <davis.benny@intel.com>