### PR TITLE
[Update] Spring boot starter jetty dependency version roll over

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jetty</artifactId>
-      <version>2.3.5.RELEASE</version>
+      <version>2.4.0</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Updating spring-boot-starter-jetty to latest version.

Signed-off-by: Darshini Parikh <darshini.k.parikh@intel.com>