### PR TITLE
Auto-generate JWT signing key

### DIFF
--- a/demo/cmdDocker.sh
+++ b/demo/cmdDocker.sh
@@ -6,6 +6,7 @@ SSL_KEY_STORE="rendezvous-keystore.jks"
 JAVA_SSL_PARAMS="-Dserver.ssl.key-store=/home/sdouser/certs/$SSL_KEY_STORE -Dserver.ssl.key-store-password=$SSL_KEY_STORE_PASSWORD"
 JAVA_REDIS_PARAMS="-Dredis.host=$REDIS_HOST -Dredis.password=$REDIS_PASSWORD -Dredis.port=$REDIS_PORT"
 TRUST_STORE_SSL_PARAM="-Djavax.net.ssl.trustStore=/home/sdouser/certs/rendezvous-trusterRootCA.jks -Djavax.net.ssl.trustStorePassword=$SSL_TRUST_STORE_PASSWORD"
+HMAC_SECRET="-Drendezvous.hmacSecret=$(tr -cd 'a-f0-9' < /dev/urandom | head -c128)"
 
 PROXY_SETTINGS=""
 if [ "" != "${http_proxy}" ]
@@ -21,4 +22,4 @@ then
     PROXY_SETTINGS="${PROXY_SETTINGS} -Dhttps.proxyHost=${HTTPS_PROXY_URL} -Dhttps.proxyPort=${HTTPS_PROXY_PORT}"
 fi
 
-java ${PROXY_SETTINGS} ${JAVA_REDIS_PARAMS} ${TRUST_STORE_SSL_PARAM} ${JAVA_SSL_PARAMS} -jar /home/sdouser/rendezvous-service-*.war
+java ${PROXY_SETTINGS} ${JAVA_REDIS_PARAMS} ${TRUST_STORE_SSL_PARAM} ${JAVA_SSL_PARAMS} ${HMAC_SECRET} -jar /home/sdouser/rendezvous-service-*.war

--- a/demo/rendezvous.env
+++ b/demo/rendezvous.env
@@ -9,8 +9,10 @@ SSL_TRUST_STORE_PASSWORD=123456
 SSL_KEY_STORE=file:///certs/rendezvous-keystore.jks
 SSL_KEY_STORE_PASSWORD=123456
 
-# RENDEZVOUS_HMACSECRET - the BASE64-encoded algorithm-specific signing key to use to digitally sign the JWT
-RENDEZVOUS_HMACSECRET="efe08a5df188dac44a4534c9f8ca0aed1b7ef6003622a07bf8a331134b3c1af427a6d7ee298f25d7f911ae495a8356e4636c19ada91643bd0d8b4f7b2bb97156"
+# RENDEZVOUS_HMACSECRET - hex-encoded algorithm-specific signing key used to digitally sign the JWT
+# This key is generated while deploying the service. Care must be taken to ensure the cryptographic
+# strength of this key. Recommended to have at least 64 bytes long string.
+RENDEZVOUS_HMACSECRET=""
 
 # RENDEZVOUS_SIGNATUREVERIFICATION - the signatures are not checked when the variable is set to false (possible options true | false)
 RENDEZVOUS_SIGNATUREVERIFICATION=true

--- a/rendezvousService.sh
+++ b/rendezvousService.sh
@@ -5,6 +5,7 @@
 
 java -Dserver.ssl.key-store=./certs/rendezvous-keystore.jks -Dserver.ssl.key-store-password=123456 \
      -Djavax.net.ssl.trustStore=./certs/rendezvous-trusterRootCA.jks -Djavax.net.ssl.trustStorePassword=123456 \
+     -Drendezvous.hmacSecret=$(tr -cd 'a-f0-9' < /dev/urandom | head -c128) \
      -Dserver.port=8000 -Drendezvous.verificationServiceHost=https://verify.epid-sbx.trustedservices.intel.com \
      -Dspring.profiles.active=production \
      -jar ./target/rendezvous-service-*.war

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 
 info.build.version=1.10.1
 
-rendezvous.hmacSecret=efe08a5df188dac44a4534c9f8ca0aed1b7ef6003622a07bf8a331134b3c1af427a6d7ee298f25d7f911ae495a8356e4636c19ada91643bd0d8b4f7b2bb97156
+rendezvous.hmacSecret=
 rendezvous.tOTokenExpirationTime=15
 rendezvous.verificationServiceHost=https://verify.epid-sbx.trustedservices.intel.com
 rendezvous.ownershipVoucherMaxEntries=10


### PR DESCRIPTION
Currently the default JWT signing key is updated in the properties file.
In case this is not overridden by the environment variable, all deployed
units end up using the default keys. This creates a security
vulnerability where a third-party can pass-on invalid TO1D blobs to the
device. The overall impact is minimal as the subsequent messages during
TO2 protocol would stop the third-party gaining access to the device.

The issue is solved by removing the default keys and ensuring the key is
auto-generated while the service starts.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>