### PR TITLE
Update version of third-party packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <bcprov-jdk15on.version>1.68</bcprov-jdk15on.version>
     <bcpkix-jdk15on.version>1.68</bcpkix-jdk15on.version>
     <guava.version>30.1.1-jre</guava.version>
-    <jackson-databind.version>2.11.1</jackson-databind.version>
+    <jackson-databind.version>2.11.4</jackson-databind.version>
     <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,26 +18,50 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.8.RELEASE</version>
+    <version>2.3.11.RELEASE</version>
     <relativePath/>
   </parent>
 
   <properties>
-    <tomcat.version>9.0.43</tomcat.version>
+    <bcprov-jdk15on.version>1.68</bcprov-jdk15on.version>
+    <bcpkix-jdk15on.version>1.68</bcpkix-jdk15on.version>
+    <guava.version>30.1.1-jre</guava.version>
+    <jackson-databind.version>2.11.1</jackson-databind.version>
+    <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
+    <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
+    <jaxb-api.version>2.3.1</jaxb-api.version>
+    <jedis.version>3.2.0</jedis.version>
+    <jjwt.version>0.9.1</jjwt.version>
+    <logstash-logback-encoder.version>6.6</logstash-logback-encoder.version>
+    <lombok.version>1.18.20</lombok.version>
+    <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
+    <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
+    <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+    <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
+    <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+    <powermock-api-mockito2.version>2.0.7</powermock-api-mockito2.version>
+    <powermock-module-testng.version>2.0.7</powermock-module-testng.version>
+    <spring-boot.version>2.3.11.RELEASE</spring-boot.version>
+    <spring.version>5.3.7</spring.version>
+    <testng.version>7.4.0</testng.version>
+    <tomcat.version>9.0.46</tomcat.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-rest</artifactId>
-      <version>2.3.8.RELEASE</version>
+      <version>${spring-boot.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jetty</artifactId>
-      <version>2.3.8.RELEASE</version>
+      <version>${spring-boot.version}</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -50,13 +74,13 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
-      <version>2.3.8.RELEASE</version>
+      <version>${spring-boot.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-aspects</artifactId>
-      <version>5.2.12.RELEASE</version>
+      <version>${spring.version}</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -69,63 +93,63 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.68</version>
+      <version>${bcprov-jdk15on.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.66</version>
+      <version>${bcpkix-jdk15on.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt</artifactId>
-      <version>0.9.1</version>
+      <version>${jjwt.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>3.2.0</version>
+      <version>${jedis.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>30.0-jre</version>
+      <version>${guava.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>net.logstash.logback</groupId>
       <artifactId>logstash-logback-encoder</artifactId>
-      <version>6.3</version>
+      <version>${logstash-logback-encoder.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.11.1</version>
+      <version>${jackson-databind.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.12</version>
+      <version>${lombok.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
+      <version>${jaxb-api.version}</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -138,28 +162,28 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <version>${javax.servlet-api.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>7.1.0</version>
+      <version>${testng.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito2</artifactId>
-      <version>2.0.7</version>
+      <version>${powermock-api-mockito2.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-testng</artifactId>
-      <version>2.0.7</version>
+      <version>${powermock-module-testng.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -176,7 +200,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>${maven-compiler-plugin.version}</version>
         <configuration>
           <release>11</release>
         </configuration>
@@ -184,7 +208,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.3.8.RELEASE</version>
+        <version>${spring-boot.version}</version>
         <executions>
           <execution>
             <goals>
@@ -196,7 +220,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>${maven-dependency-plugin.version}</version>
         <executions>
           <execution>
             <id>copy-installed</id>
@@ -221,7 +245,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>${maven-resources-plugin.version}</version>
         <executions>
           <execution>
             <id>copy-certs</id>
@@ -247,7 +271,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14.1</version>
+        <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <suiteXmlFiles>
             <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
@@ -257,7 +281,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.3</version>
+        <version>${jacoco-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>jacoco-initialize</id>
@@ -277,7 +301,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>${maven-checkstyle-plugin.version}</version>
         <executions>
           <execution>
             <id>checkstyle-check</id>
@@ -300,7 +324,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>2.5</version>
+        <version>${maven-clean-plugin.version}</version>
         <configuration>
           <filesets>
             <fileset>
@@ -321,7 +345,7 @@
       <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-project-info-reports-plugin</artifactId>
-       <version>3.1.0</version>
+       <version>${maven-project-info-reports-plugin.version}</version>
      </plugin>
     </plugins>
   </build>
@@ -330,7 +354,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>${maven-javadoc-plugin.version}</version>
         <reportSets>
           <reportSet>
             <id>default</id>


### PR DESCRIPTION
Version for following third-party packages were updated.

guava (30.0-jre --> 30.1.1-jre)
javax.servlet-api (3.1.0 --> 4.0.1)
logstash-logback-encoder (6.3 -> 6.6)
bcpkix-jdk15on (1.66 -> 1.68)
lombok (1.18.12-> 1.18.20)
spring-boot (2.3.8.RELEASE -> 2.3.11.RELEASE)
testng (7.1.0 -> 7.4.0)

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>