### PR TITLE
Eliminating conversion of epoch time to date format

### DIFF
--- a/src/main/java/org/sdo/rendezvous/interceptors/JwtValidator.java
+++ b/src/main/java/org/sdo/rendezvous/interceptors/JwtValidator.java
@@ -34,11 +34,10 @@ class JwtValidator {
     String[] jwtElements = authHeader.split("\\.");
     String payload = new String(decoder.decode(jwtElements[1]));
     String expTime = payload.substring(payload.lastIndexOf(":") + 1, payload.length() - 1);
-    Date time = new Date(Long.parseLong(expTime) * 1000);
 
     // Validate the timestamp is not older than TO Token expiration time
     int diffMinutes =
-        (int) TimeUnit.MILLISECONDS.toMinutes(time.getTime() - System.currentTimeMillis());
+        (int) TimeUnit.MILLISECONDS.toMinutes(Long.parseLong(expTime) - System.currentTimeMillis());
 
     if (diffMinutes
         > TimeUnit.MILLISECONDS.toMinutes(rendezvousConfig.getToTokenExpirationTime())) {


### PR DESCRIPTION
Epoch time to date conversion eliminated to avoid unexpected behavior
observed with respect to date format based on underlying operating
system

Signed-off-by: Darshini Parikh <darshini.k.parikh@intel.com>