### PR TITLE
Upgrading spring-boot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.11.RELEASE</version>
+    <version>2.5.5</version>
     <relativePath/>
   </parent>
 
@@ -44,7 +44,7 @@
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     <powermock-api-mockito2.version>2.0.7</powermock-api-mockito2.version>
     <powermock-module-testng.version>2.0.7</powermock-module-testng.version>
-    <spring-boot.version>2.5.4</spring-boot.version>
+    <spring-boot.version>2.5.5</spring-boot.version>
     <spring.version>5.3.7</spring.version>
     <testng.version>7.4.0</testng.version>
     <tomcat.version>9.0.53</tomcat.version>


### PR DESCRIPTION
   Upgrading spring-boot-parent-starter version from 2.3.11-RELEASE ==> 2.5.4

Signed-off-by: Davis Benny <davis.benny@intel.com>