### PR TITLE
Upgrading Log4j version to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <spring.version>5.3.7</spring.version>
     <testng.version>7.4.0</testng.version>
     <tomcat.version>9.0.53</tomcat.version>
+    <log4j2.version>2.15.0</log4j2.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
  Upgrading Log4j version to 2.15.0 from 2.14.1

  CVE-2021-44228 was issued for Log4j 2.14.1 component.

Signed-off-by: Davis Benny <davis.benny@intel.com>