### PR TITLE
Upgrading dependency to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.5</version>
+    <version>2.5.7</version>
     <relativePath/>
   </parent>
 
@@ -44,11 +44,11 @@
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     <powermock-api-mockito2.version>2.0.7</powermock-api-mockito2.version>
     <powermock-module-testng.version>2.0.7</powermock-module-testng.version>
-    <spring-boot.version>2.5.5</spring-boot.version>
-    <spring.version>5.3.7</spring.version>
+    <spring-boot.version>2.5.7</spring-boot.version>
+    <spring.version>5.3.13</spring.version>
     <testng.version>7.4.0</testng.version>
-    <tomcat.version>9.0.53</tomcat.version>
-    <log4j2.version>2.15.0</log4j2.version>
+    <tomcat.version>9.0.56</tomcat.version>
+    <log4j2.version>2.16.0</log4j2.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
  Upgrading dependency to the latest version.

  org.springframework.boot:spring.* from 2.5.5 ==> 2.5.7
  spring-core => 5.3.13
  tomcat => 9.0.56
  log4j => 2.16.0

Signed-off-by: Davis Benny <davis.benny@intel.com>