### PR TITLE
Upgrading log4j version from 2.16.0 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
   </parent>
 
   <properties>
-    <bcprov-jdk15on.version>1.68</bcprov-jdk15on.version>
-    <bcpkix-jdk15on.version>1.68</bcpkix-jdk15on.version>
+    <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
+    <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
     <guava.version>30.1.1-jre</guava.version>
     <jackson-databind.version>2.11.4</jackson-databind.version>
     <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <spring.version>5.3.13</spring.version>
     <testng.version>7.4.0</testng.version>
     <tomcat.version>9.0.56</tomcat.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
  Upgrading log4j version from 2.16.0 to 2.17.1.

Signed-off-by: Davis Benny <davis.benny@intel.com>